### PR TITLE
一覧画面でcardコンポーネントの表示ができる

### DIFF
--- a/intern-book-app/src/app/app.module.ts
+++ b/intern-book-app/src/app/app.module.ts
@@ -14,12 +14,14 @@ import { AppComponent } from './app.component';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ToolbarComponent } from './components/toolbar/toolbar.component';
 import { ListComponent } from './pages/list/list.component';
+import { CardComponent } from './components/card/card.component';
 
 @NgModule({
   declarations: [
     AppComponent,
     ToolbarComponent,
-    ListComponent
+    ListComponent,
+    CardComponent
   ],
   imports: [
     MatCardModule,

--- a/intern-book-app/src/app/components/card/card.component.css
+++ b/intern-book-app/src/app/components/card/card.component.css
@@ -1,0 +1,4 @@
+.book-info-card{
+  margin: 36px;
+  padding: 20px;
+}

--- a/intern-book-app/src/app/components/card/card.component.html
+++ b/intern-book-app/src/app/components/card/card.component.html
@@ -1,0 +1,19 @@
+<div *ngFor="let book of books">
+  <mat-card class="book-info-card">
+    <mat-card-title>
+      <h1>{{book.name}}</h1>
+    </mat-card-title>
+
+    <mat-card-content>
+      {{book.detail}}
+    </mat-card-content>
+
+    <mat-card-content>
+      評価点：{{book.evaluation}}点
+    </mat-card-content>
+
+    <mat-card-actions align="end">
+      <button mat-raised-button color="warn">削除</button>
+    </mat-card-actions>
+  </mat-card>
+</div>

--- a/intern-book-app/src/app/components/card/card.component.spec.ts
+++ b/intern-book-app/src/app/components/card/card.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CardComponent } from './card.component';
+
+describe('CardComponent', () => {
+  let component: CardComponent;
+  let fixture: ComponentFixture<CardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ CardComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(CardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/intern-book-app/src/app/components/card/card.component.ts
+++ b/intern-book-app/src/app/components/card/card.component.ts
@@ -1,0 +1,10 @@
+import { Component, Input } from '@angular/core';
+import { Book } from '../../types/book';
+@Component({
+  selector: 'app-card',
+  templateUrl: './card.component.html',
+  styleUrls: ['./card.component.css']
+})
+export class CardComponent {
+  @Input() books? : Book[];
+}

--- a/intern-book-app/src/app/pages/list/list.component.css
+++ b/intern-book-app/src/app/pages/list/list.component.css
@@ -1,11 +1,6 @@
 
 .register-card{
-  margin: 30px;
-  padding: 20px;
-}
-
-.book-info-card{
-  margin: 30px;
+  margin: 36px;
   padding: 20px;
 }
 

--- a/intern-book-app/src/app/pages/list/list.component.html
+++ b/intern-book-app/src/app/pages/list/list.component.html
@@ -25,23 +25,4 @@
     <button mat-raised-button color="primary">追加</button>
   </mat-card-actions>
 </mat-card>
-
-<div *ngFor="let book of bookList" class="contents-space">
-  <mat-card class="book-info-card">
-    <mat-card-title>
-      <h1>{{book.name}}</h1>
-    </mat-card-title>
-
-    <mat-card-content>
-      {{book.detail}}
-    </mat-card-content>
-
-    <mat-card-content>
-      評価点：{{book.evaluation}}点
-    </mat-card-content>
-
-    <mat-card-actions align="end">
-      <button mat-raised-button color="warn">削除</button>
-    </mat-card-actions>
-  </mat-card>
-</div>
+<app-card [books]="bookList"></app-card>

--- a/intern-book-app/src/styles.css
+++ b/intern-book-app/src/styles.css
@@ -1,4 +1,4 @@
 /* You can add global styles to this file, and also import other style files */
 
-html, body { height: 100%; }
+html, body { height: auto; }
 body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }


### PR DESCRIPTION
## Checklist for Developer
- [x] 最新のdevelopブランチをPullした。Pulled the latest develop branch.
  - できない理由 Reason not to do: 
- [x] Pull RequestをIssueに紐付けた。Connected with the issue.
- [x] 自分をAssignした。Assigned yourself.
- [x] レビュワーを指定した。Assigned reviewer.

## 📝 そのほかの関連するIssue / Related issues other than connected one
<!-- ZenHubで紐付けられなかったIssueの番号を記載 -->
<!-- List down issue numbers which could not be connected with ZenHub -->
- #10 
- #0

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- componentsフォルダの中にcardコンポーネントを作成
- cardコンポーネントにBookインターフェイスとinputをインポート
- 子コンポーネントに@inputで修飾したBook[]型の変数を宣言
- 親コンポーネントで作成したモックデータと子コンポーネントの@inputで修飾された変数をバインディング
- listコンポーネントにcardコンポーネントを表示
- styles.cssのbodyクラスのheightを100％からautoに変更

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
<img width="1680" alt="スクリーンショット 2023-03-17 15 30 58" src="https://user-images.githubusercontent.com/118503367/225830086-b6c1d08b-f687-4c81-a956-5ad7737363e5.png">
-下にスペースができました

## レビューするポイント (Points for review):
<!-- テストケースを箇条書きで。Issueに書いてあればコピーしてください。 -->
<!-- List down test cases for this PR. Or you can copy that from the issue. -->
 - cardコンポーネントが正しく表示されるか
 